### PR TITLE
Make transaction selector iterative and reduce consensus<->mempool sync gap 

### DIFF
--- a/consensus/core/src/api/mod.rs
+++ b/consensus/core/src/api/mod.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use crate::{
     acceptance_data::AcceptanceData,
-    block::{Block, BlockTemplate, TemplateTransactionSelector},
+    block::{Block, BlockTemplate, TemplateBuildMode, TemplateTransactionSelector},
     block_count::BlockCount,
     blockstatus::BlockStatus,
     coinbase::MinerData,
@@ -31,6 +31,7 @@ pub trait ConsensusApi: Send + Sync {
         &self,
         miner_data: MinerData,
         tx_selector: Box<dyn TemplateTransactionSelector>,
+        build_mode: TemplateBuildMode,
     ) -> Result<BlockTemplate, RuleError> {
         unimplemented!()
     }

--- a/consensus/core/src/api/mod.rs
+++ b/consensus/core/src/api/mod.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use crate::{
     acceptance_data::AcceptanceData,
-    block::{Block, BlockTemplate},
+    block::{Block, BlockTemplate, TemplateTransactionSelector},
     block_count::BlockCount,
     blockstatus::BlockStatus,
     coinbase::MinerData,
@@ -27,7 +27,11 @@ pub type BlockValidationFuture = BoxFuture<'static, BlockProcessResult<BlockStat
 /// Abstracts the consensus external API
 #[allow(unused_variables)]
 pub trait ConsensusApi: Send + Sync {
-    fn build_block_template(&self, miner_data: MinerData, txs: Vec<Transaction>) -> Result<BlockTemplate, RuleError> {
+    fn build_block_template(
+        &self,
+        miner_data: MinerData,
+        tx_selector: Box<dyn TemplateTransactionSelector>,
+    ) -> Result<BlockTemplate, RuleError> {
         unimplemented!()
     }
 

--- a/consensus/core/src/block.rs
+++ b/consensus/core/src/block.rs
@@ -1,6 +1,10 @@
 use std::sync::Arc;
 
-use crate::{coinbase::MinerData, header::Header, tx::Transaction};
+use crate::{
+    coinbase::MinerData,
+    header::Header,
+    tx::{Transaction, TransactionId},
+};
 use kaspa_hashes::Hash;
 
 /// A mutable block structure where header and transactions within can still be mutated.
@@ -62,6 +66,11 @@ impl Block {
     pub fn from_precomputed_hash(hash: Hash, parents: Vec<Hash>) -> Block {
         Block::from_header(Header::from_precomputed_hash(hash, parents))
     }
+}
+
+pub trait TemplateTransactionSelector {
+    fn select_transactions(&mut self) -> Vec<Transaction>;
+    fn reject_selection(&mut self, tx_id: TransactionId);
 }
 
 /// A block template for miners.

--- a/consensus/core/src/block.rs
+++ b/consensus/core/src/block.rs
@@ -68,9 +68,20 @@ impl Block {
     }
 }
 
+/// An abstraction for a recallable transaction selector with persistent state
 pub trait TemplateTransactionSelector {
+    /// Expected to return a batch of transactions which were not previously selected.
+    /// The batch will typically contain sufficient transactions to fill the block
+    /// mass (along with the previously unrejected txs), or will drain the selector    
     fn select_transactions(&mut self) -> Vec<Transaction>;
+
+    /// Should be used to report invalid transactions obtained from the *most recent*
+    /// `select_transactions` call. Implementors should use this call to internally
+    /// track the selection state and discard the rejected tx from internal occupation calculations
     fn reject_selection(&mut self, tx_id: TransactionId);
+
+    /// Determine whether this was an overall successful selection episode
+    fn is_successful(&self) -> bool;
 }
 
 /// A block template for miners.

--- a/consensus/core/src/block.rs
+++ b/consensus/core/src/block.rs
@@ -84,6 +84,18 @@ pub trait TemplateTransactionSelector {
     fn is_successful(&self) -> bool;
 }
 
+/// Block template build mode
+#[derive(Clone, Copy, Debug)]
+pub enum TemplateBuildMode {
+    /// Block template build can possibly fail if `TemplateTransactionSelector::is_successful` deems the operation unsuccessful.
+    ///
+    /// In such a case, the build fails with `BlockRuleError::InvalidTransactionsInNewBlock`.
+    Standard,
+
+    /// Block template build always succeeds. The built block contains only the validated transactions.
+    Infallible,
+}
+
 /// A block template for miners.
 #[derive(Debug, Clone)]
 pub struct BlockTemplate {

--- a/consensus/core/src/errors/block.rs
+++ b/consensus/core/src/errors/block.rs
@@ -1,4 +1,4 @@
-use std::fmt::Display;
+use std::{collections::HashMap, fmt::Display};
 
 use crate::{
     constants,
@@ -140,7 +140,7 @@ pub enum RuleError {
     InvalidTransactionsInUtxoContext(usize, usize),
 
     #[error("invalid transactions in new block template")]
-    InvalidTransactionsInNewBlock(Vec<(TransactionId, TxRuleError)>),
+    InvalidTransactionsInNewBlock(HashMap<TransactionId, TxRuleError>),
 
     #[error("DAA window data has only {0} entries")]
     InsufficientDaaWindowSize(usize),

--- a/consensus/src/consensus/mod.rs
+++ b/consensus/src/consensus/mod.rs
@@ -41,7 +41,7 @@ use crate::{
 use kaspa_consensus_core::{
     acceptance_data::AcceptanceData,
     api::{BlockValidationFuture, ConsensusApi},
-    block::{Block, BlockTemplate, TemplateTransactionSelector},
+    block::{Block, BlockTemplate, TemplateBuildMode, TemplateTransactionSelector},
     block_count::BlockCount,
     blockhash::BlockHashExtensions,
     blockstatus::BlockStatus,
@@ -357,8 +357,9 @@ impl ConsensusApi for Consensus {
         &self,
         miner_data: MinerData,
         tx_selector: Box<dyn TemplateTransactionSelector>,
+        build_mode: TemplateBuildMode,
     ) -> Result<BlockTemplate, RuleError> {
-        self.virtual_processor.build_block_template(miner_data, tx_selector)
+        self.virtual_processor.build_block_template(miner_data, tx_selector, build_mode)
     }
 
     fn validate_and_insert_block(&self, block: Block) -> BlockValidationFuture {

--- a/consensus/src/consensus/mod.rs
+++ b/consensus/src/consensus/mod.rs
@@ -41,7 +41,7 @@ use crate::{
 use kaspa_consensus_core::{
     acceptance_data::AcceptanceData,
     api::{BlockValidationFuture, ConsensusApi},
-    block::{Block, BlockTemplate},
+    block::{Block, BlockTemplate, TemplateTransactionSelector},
     block_count::BlockCount,
     blockhash::BlockHashExtensions,
     blockstatus::BlockStatus,
@@ -353,8 +353,12 @@ impl Consensus {
 }
 
 impl ConsensusApi for Consensus {
-    fn build_block_template(&self, miner_data: MinerData, txs: Vec<Transaction>) -> Result<BlockTemplate, RuleError> {
-        self.virtual_processor.build_block_template(miner_data, txs)
+    fn build_block_template(
+        &self,
+        miner_data: MinerData,
+        tx_selector: Box<dyn TemplateTransactionSelector>,
+    ) -> Result<BlockTemplate, RuleError> {
+        self.virtual_processor.build_block_template(miner_data, tx_selector)
     }
 
     fn validate_and_insert_block(&self, block: Block) -> BlockValidationFuture {

--- a/consensus/src/pipeline/virtual_processor/processor.rs
+++ b/consensus/src/pipeline/virtual_processor/processor.rs
@@ -48,7 +48,7 @@ use crate::{
 };
 use kaspa_consensus_core::{
     acceptance_data::AcceptanceData,
-    block::{BlockTemplate, MutableBlock},
+    block::{BlockTemplate, MutableBlock, TemplateTransactionSelector},
     blockstatus::BlockStatus::{StatusDisqualifiedFromChain, StatusUTXOValid},
     coinbase::MinerData,
     config::genesis::GenesisBlock,
@@ -787,8 +787,15 @@ impl VirtualStateProcessor {
         Ok(())
     }
 
-    pub fn build_block_template(&self, miner_data: MinerData, txs: Vec<Transaction>) -> Result<BlockTemplate, RuleError> {
+    pub fn build_block_template(
+        &self,
+        miner_data: MinerData,
+        mut tx_selector: Box<dyn TemplateTransactionSelector>,
+    ) -> Result<BlockTemplate, RuleError> {
         // TODO: tests
+        //
+
+        let txs = tx_selector.select_transactions();
         let virtual_read = self.virtual_stores.read();
         let virtual_state = virtual_read.state.get().unwrap();
         let virtual_utxo_view = &virtual_read.utxo_set;

--- a/consensus/src/pipeline/virtual_processor/tests.rs
+++ b/consensus/src/pipeline/virtual_processor/tests.rs
@@ -30,6 +30,10 @@ impl TemplateTransactionSelector for OnetimeTxSelector {
     fn reject_selection(&mut self, _tx_id: kaspa_consensus_core::tx::TransactionId) {
         unimplemented!()
     }
+
+    fn is_successful(&self) -> bool {
+        true
+    }
 }
 
 struct TestContext {

--- a/consensus/src/pipeline/virtual_processor/tests.rs
+++ b/consensus/src/pipeline/virtual_processor/tests.rs
@@ -1,7 +1,7 @@
 use crate::{consensus::test_consensus::TestConsensus, model::services::reachability::ReachabilityService};
 use kaspa_consensus_core::{
     api::ConsensusApi,
-    block::{Block, BlockTemplate, MutableBlock, TemplateTransactionSelector},
+    block::{Block, BlockTemplate, MutableBlock, TemplateBuildMode, TemplateTransactionSelector},
     blockhash,
     blockstatus::BlockStatus,
     coinbase::MinerData,
@@ -104,7 +104,11 @@ impl TestContext {
     pub fn build_block_template(&self, nonce: u64, timestamp: u64) -> BlockTemplate {
         let mut t = self
             .consensus
-            .build_block_template(self.miner_data.clone(), Box::new(OnetimeTxSelector::new(Default::default())))
+            .build_block_template(
+                self.miner_data.clone(),
+                Box::new(OnetimeTxSelector::new(Default::default())),
+                TemplateBuildMode::Standard,
+            )
             .unwrap();
         t.block.header.timestamp = timestamp;
         t.block.header.nonce = nonce;

--- a/mining/src/block_template/builder.rs
+++ b/mining/src/block_template/builder.rs
@@ -1,7 +1,11 @@
 use super::{errors::BuilderResult, policy::Policy};
 use crate::{block_template::selector::TransactionsSelector, model::candidate_tx::CandidateTransaction};
 use kaspa_consensus_core::{
-    api::ConsensusApi, block::BlockTemplate, coinbase::MinerData, merkle::calc_hash_merkle_root, tx::COINBASE_TRANSACTION_INDEX,
+    api::ConsensusApi,
+    block::{BlockTemplate, TemplateBuildMode},
+    coinbase::MinerData,
+    merkle::calc_hash_merkle_root,
+    tx::COINBASE_TRANSACTION_INDEX,
 };
 use kaspa_core::{
     debug,
@@ -86,11 +90,12 @@ impl BlockTemplateBuilder {
         consensus: &dyn ConsensusApi,
         miner_data: &MinerData,
         transactions: Vec<CandidateTransaction>,
+        build_mode: TemplateBuildMode,
     ) -> BuilderResult<BlockTemplate> {
         let _sw = Stopwatch::<20>::with_threshold("build_block_template op");
         debug!("Considering {} transactions for a new block template", transactions.len());
         let selector = Box::new(TransactionsSelector::new(self.policy.clone(), transactions));
-        Ok(consensus.build_block_template(miner_data.clone(), selector)?)
+        Ok(consensus.build_block_template(miner_data.clone(), selector, build_mode)?)
     }
 
     /// modify_block_template clones an existing block template, modifies it to the requested coinbase data and updates the timestamp

--- a/mining/src/block_template/builder.rs
+++ b/mining/src/block_template/builder.rs
@@ -1,4 +1,4 @@
-use super::{errors::BuilderResult, policy::Policy};
+use super::{errors::BuilderResult, policy::Policy, selector::TxSelector};
 use crate::{block_template::selector::TransactionsSelector, model::candidate_tx::CandidateTransaction};
 use kaspa_consensus_core::{
     api::ConsensusApi,
@@ -105,7 +105,7 @@ impl BlockTemplateBuilder {
     }
 
     pub(crate) fn reject_transaction(&mut self, transaction_id: TransactionId) {
-        self.selector.reject(transaction_id);
+        self.selector.reject_selection(transaction_id);
     }
 
     pub(crate) fn candidates_len(&self) -> usize {

--- a/mining/src/block_template/model/tx.rs
+++ b/mining/src/block_template/model/tx.rs
@@ -1,14 +1,11 @@
 pub(crate) struct SelectableTransaction {
     pub(crate) gas_limit: u64,
     pub(crate) p: f64,
-
-    /// Has this candidate been rejected by the consensus?
-    pub(crate) is_rejected: bool,
 }
 
 impl SelectableTransaction {
     pub(crate) fn new(tx_value: f64, gas_limit: u64, alpha: i32) -> Self {
-        Self { gas_limit, p: tx_value.powi(alpha), is_rejected: false }
+        Self { gas_limit, p: tx_value.powi(alpha) }
     }
 }
 
@@ -22,6 +19,7 @@ pub(crate) struct Candidate {
 
     /// Range start in the candidate list total_p space
     pub(crate) start: f64,
+
     /// Range end in the candidate list total_p space
     pub(crate) end: f64,
 
@@ -35,6 +33,7 @@ impl Candidate {
     }
 }
 
+#[derive(Default)]
 pub(crate) struct CandidateList {
     pub(crate) candidates: Vec<Candidate>,
     pub(crate) total_p: f64,
@@ -45,12 +44,10 @@ impl CandidateList {
         let mut candidates = Vec::with_capacity(selectable_txs.len());
         let mut total_p = 0.0;
         selectable_txs.iter().enumerate().for_each(|(i, tx)| {
-            if !tx.is_rejected {
-                let current_p = tx.p;
-                let candidate = Candidate::new(i, total_p, total_p + current_p);
-                candidates.push(candidate);
-                total_p += current_p;
-            }
+            let current_p = tx.p;
+            let candidate = Candidate::new(i, total_p, total_p + current_p);
+            candidates.push(candidate);
+            total_p += current_p;
         });
         Self { candidates, total_p }
     }

--- a/mining/src/block_template/selector.rs
+++ b/mining/src/block_template/selector.rs
@@ -206,8 +206,9 @@ impl TransactionsSelector {
 
     fn reset_selection(&mut self) {
         assert_eq!(self.transactions.len(), self.selectable_txs.len());
+        self.selected_txs.clear();
         // TODO: consider to min with the approximated amount of txs which fit into max block mass
-        self.selected_txs = Vec::with_capacity(self.transactions.len());
+        self.selected_txs.reserve_exact(self.transactions.len());
         self.selected_txs_map = None;
     }
 

--- a/mining/src/block_template/selector.rs
+++ b/mining/src/block_template/selector.rs
@@ -250,7 +250,7 @@ impl TemplateTransactionSelector for TransactionsSelector {
 
     fn is_successful(&self) -> bool {
         // TODO: comment + constants
-        self.transactions.is_empty()
+        self.overall_rejections == 0
             || (self.total_mass as f64) > self.policy.max_block_mass as f64 * 0.8
             || (self.overall_rejections as f64) < self.transactions.len() as f64 * 0.2
     }

--- a/mining/src/block_template/selector.rs
+++ b/mining/src/block_template/selector.rs
@@ -249,10 +249,13 @@ impl TemplateTransactionSelector for TransactionsSelector {
     }
 
     fn is_successful(&self) -> bool {
-        // TODO: comment + constants
+        const SUFFICIENT_MASS_THRESHOLD: f64 = 0.8;
+        const LOW_REJECTION_FRACTION: f64 = 0.2;
+
+        // We consider the operation successful if either mass occupation is above 80% or rejection rate is below 20%
         self.overall_rejections == 0
-            || (self.total_mass as f64) > self.policy.max_block_mass as f64 * 0.8
-            || (self.overall_rejections as f64) < self.transactions.len() as f64 * 0.2
+            || (self.total_mass as f64) > self.policy.max_block_mass as f64 * SUFFICIENT_MASS_THRESHOLD
+            || (self.overall_rejections as f64) < self.transactions.len() as f64 * LOW_REJECTION_FRACTION
     }
 }
 

--- a/mining/src/manager.rs
+++ b/mining/src/manager.rs
@@ -85,17 +85,12 @@ impl MiningManager {
         debug!("Building a new block template...");
         let _swo = Stopwatch::<22>::with_threshold("build_block_template full loop");
         let mut attempts: u64 = 0;
-        let transactions = self.block_candidate_transactions();
-        let mut block_template_builder = BlockTemplateBuilder::new(self.config.maximum_mass_per_block, transactions);
         loop {
             attempts += 1;
 
-            // TODO: consider a parameter forcing the consensus to build a template with the remaining successfully validated transactions
-            //
-            // let force_build = attempts == self.config.maximum_build_block_template_attempts;
-            // match block_template_builder.build_block_template(consensus, miner_data, force_build) {
-
-            match block_template_builder.build_block_template(consensus, miner_data) {
+            let transactions = self.block_candidate_transactions();
+            let block_template_builder = BlockTemplateBuilder::new(self.config.maximum_mass_per_block);
+            match block_template_builder.build_block_template(consensus, miner_data, transactions) {
                 Ok(block_template) => {
                     let block_template = cache_lock.set_immutable_cached_template(block_template);
                     match attempts {
@@ -125,21 +120,11 @@ impl MiningManager {
                     return Ok(block_template.as_ref().clone());
                 }
                 Err(BuilderError::ConsensusError(BlockRuleError::InvalidTransactionsInNewBlock(invalid_transactions))) => {
-                    // Do not refetch candidates if not absolutely necessary so we do not lock the mempool
-                    // and optimize for the quickest possible resolution
-                    let keep_candidates = block_template_builder.candidates_len()
-                        > self.config.ready_transactions_refetch_limit + invalid_transactions.len()
-                        || attempts + 1 >= self.config.maximum_build_block_template_attempts;
-
                     let mut missing_outpoint: usize = 0;
                     let mut invalid: usize = 0;
 
                     let mut mempool_write = self.mempool.write();
                     invalid_transactions.iter().for_each(|(x, err)| {
-                        if keep_candidates {
-                            block_template_builder.reject_transaction(*x);
-                        }
-
                         // On missing outpoints, the most likely is that the tx was already in a block accepted by
                         // the consensus but not yet processed by handle_new_block_transactions(). Another possibility
                         // is a double spend. In both cases, we simply remove the transaction but keep its redeemers.
@@ -179,12 +164,6 @@ impl MiningManager {
                         "Building a new block template failed for {} txs missing outpoint and {} invalid txs",
                         missing_outpoint, invalid
                     );
-
-                    // Refetch candidates if asked to
-                    if !keep_candidates {
-                        let transactions = self.block_candidate_transactions();
-                        block_template_builder.update_transactions(transactions);
-                    }
                 }
                 Err(err) => {
                     warn!("Building a new block template failed: {}", err);
@@ -204,8 +183,8 @@ impl MiningManager {
     }
 
     #[cfg(test)]
-    pub(crate) fn block_template_builder(&self, transactions: Vec<CandidateTransaction>) -> BlockTemplateBuilder {
-        BlockTemplateBuilder::new(self.config.maximum_mass_per_block, transactions)
+    pub(crate) fn block_template_builder(&self) -> BlockTemplateBuilder {
+        BlockTemplateBuilder::new(self.config.maximum_mass_per_block)
     }
 
     /// validate_and_insert_transaction validates the given transaction, and

--- a/mining/src/manager_tests.rs
+++ b/mining/src/manager_tests.rs
@@ -16,6 +16,7 @@ mod tests {
     use kaspa_addresses::{Address, Prefix, Version};
     use kaspa_consensus_core::{
         api::ConsensusApi,
+        block::TemplateBuildMode,
         coinbase::MinerData,
         constants::{MAX_TX_IN_SEQUENCE_NUM, SOMPI_PER_KASPA, TX_VERSION},
         errors::tx::{TxResult, TxRuleError},
@@ -847,7 +848,7 @@ mod tests {
 
         // Build a fresh template for coinbase2 as a reference
         let builder = mining_manager.block_template_builder();
-        let result = builder.build_block_template(consensus, &miner_data_2, transactions);
+        let result = builder.build_block_template(consensus, &miner_data_2, transactions, TemplateBuildMode::Standard);
         assert!(result.is_ok(), "build block template failed for miner data 2");
         let expected_template = result.unwrap();
 

--- a/mining/src/manager_tests.rs
+++ b/mining/src/manager_tests.rs
@@ -846,8 +846,8 @@ mod tests {
         let miner_data_2 = generate_new_coinbase(address_prefix, second_op);
 
         // Build a fresh template for coinbase2 as a reference
-        let mut builder = mining_manager.block_template_builder(transactions);
-        let result = builder.build_block_template(consensus, &miner_data_2);
+        let builder = mining_manager.block_template_builder();
+        let result = builder.build_block_template(consensus, &miner_data_2, transactions);
         assert!(result.is_ok(), "build block template failed for miner data 2");
         let expected_template = result.unwrap();
 

--- a/mining/src/mempool/config.rs
+++ b/mining/src/mempool/config.rs
@@ -104,8 +104,8 @@ impl Config {
         Self {
             maximum_transaction_count: DEFAULT_MAXIMUM_TRANSACTION_COUNT,
             maximum_ready_transaction_count: DEFAULT_MAXIMUM_READY_TRANSACTION_COUNT,
-            maximum_build_block_template_attempts: DEFAULT_MAXIMUM_BUILD_BLOCK_TEMPLATE_ATTEMPTS,
-            ready_transactions_refetch_limit: DEFAULT_READY_TRANSACTIONS_REFETCH_LIMIT,
+            maximum_build_block_template_attempts: DEFAULT_MAXIMUM_BUILD_BLOCK_TEMPLATE_ATTEMPTS, // TODO
+            ready_transactions_refetch_limit: DEFAULT_READY_TRANSACTIONS_REFETCH_LIMIT,           // TODO
             transaction_expire_interval_daa_score: DEFAULT_TRANSACTION_EXPIRE_INTERVAL_SECONDS * 1000 / target_milliseconds_per_block,
             transaction_expire_scan_interval_daa_score: DEFAULT_TRANSACTION_EXPIRE_SCAN_INTERVAL_SECONDS * 1000
                 / target_milliseconds_per_block,

--- a/mining/src/mempool/config.rs
+++ b/mining/src/mempool/config.rs
@@ -3,8 +3,6 @@ use kaspa_consensus_core::constants::TX_VERSION;
 pub(crate) const DEFAULT_MAXIMUM_TRANSACTION_COUNT: u64 = 1_000_000;
 pub(crate) const DEFAULT_MAXIMUM_READY_TRANSACTION_COUNT: u64 = 100_000;
 pub(crate) const DEFAULT_MAXIMUM_BUILD_BLOCK_TEMPLATE_ATTEMPTS: u64 = 5;
-// TODO: revisit this value
-pub(crate) const DEFAULT_READY_TRANSACTIONS_REFETCH_LIMIT: usize = 2_500;
 
 pub(crate) const DEFAULT_TRANSACTION_EXPIRE_INTERVAL_SECONDS: u64 = 60;
 pub(crate) const DEFAULT_TRANSACTION_EXPIRE_SCAN_INTERVAL_SECONDS: u64 = 10;
@@ -34,7 +32,6 @@ pub struct Config {
     pub maximum_transaction_count: u64,
     pub maximum_ready_transaction_count: u64,
     pub maximum_build_block_template_attempts: u64,
-    pub ready_transactions_refetch_limit: usize,
     pub transaction_expire_interval_daa_score: u64,
     pub transaction_expire_scan_interval_daa_score: u64,
     pub transaction_expire_scan_interval_milliseconds: u64,
@@ -58,7 +55,6 @@ impl Config {
         maximum_transaction_count: u64,
         maximum_ready_transaction_count: u64,
         maximum_build_block_template_attempts: u64,
-        ready_transactions_refetch_limit: usize,
         transaction_expire_interval_daa_score: u64,
         transaction_expire_scan_interval_daa_score: u64,
         transaction_expire_scan_interval_milliseconds: u64,
@@ -79,7 +75,6 @@ impl Config {
             maximum_transaction_count,
             maximum_ready_transaction_count,
             maximum_build_block_template_attempts,
-            ready_transactions_refetch_limit,
             transaction_expire_interval_daa_score,
             transaction_expire_scan_interval_daa_score,
             transaction_expire_scan_interval_milliseconds,
@@ -104,8 +99,7 @@ impl Config {
         Self {
             maximum_transaction_count: DEFAULT_MAXIMUM_TRANSACTION_COUNT,
             maximum_ready_transaction_count: DEFAULT_MAXIMUM_READY_TRANSACTION_COUNT,
-            maximum_build_block_template_attempts: DEFAULT_MAXIMUM_BUILD_BLOCK_TEMPLATE_ATTEMPTS, // TODO
-            ready_transactions_refetch_limit: DEFAULT_READY_TRANSACTIONS_REFETCH_LIMIT,           // TODO
+            maximum_build_block_template_attempts: DEFAULT_MAXIMUM_BUILD_BLOCK_TEMPLATE_ATTEMPTS,
             transaction_expire_interval_daa_score: DEFAULT_TRANSACTION_EXPIRE_INTERVAL_SECONDS * 1000 / target_milliseconds_per_block,
             transaction_expire_scan_interval_daa_score: DEFAULT_TRANSACTION_EXPIRE_SCAN_INTERVAL_SECONDS * 1000
                 / target_milliseconds_per_block,

--- a/mining/src/testutils/consensus_mock.rs
+++ b/mining/src/testutils/consensus_mock.rs
@@ -1,7 +1,7 @@
 use super::coinbase_mock::CoinbaseManagerMock;
 use kaspa_consensus_core::{
     api::ConsensusApi,
-    block::{BlockTemplate, MutableBlock},
+    block::{BlockTemplate, MutableBlock, TemplateTransactionSelector},
     coinbase::MinerData,
     constants::BLOCK_VERSION,
     errors::{
@@ -72,7 +72,12 @@ impl ConsensusMock {
 }
 
 impl ConsensusApi for ConsensusMock {
-    fn build_block_template(&self, miner_data: MinerData, mut txs: Vec<Transaction>) -> Result<BlockTemplate, RuleError> {
+    fn build_block_template(
+        &self,
+        miner_data: MinerData,
+        mut tx_selector: Box<dyn TemplateTransactionSelector>,
+    ) -> Result<BlockTemplate, RuleError> {
+        let mut txs = tx_selector.select_transactions();
         let coinbase_manager = CoinbaseManagerMock::new();
         let coinbase = coinbase_manager.expected_coinbase_transaction(miner_data.clone());
         txs.insert(0, coinbase.tx);

--- a/mining/src/testutils/consensus_mock.rs
+++ b/mining/src/testutils/consensus_mock.rs
@@ -1,7 +1,7 @@
 use super::coinbase_mock::CoinbaseManagerMock;
 use kaspa_consensus_core::{
     api::ConsensusApi,
-    block::{BlockTemplate, MutableBlock, TemplateTransactionSelector},
+    block::{BlockTemplate, MutableBlock, TemplateBuildMode, TemplateTransactionSelector},
     coinbase::MinerData,
     constants::BLOCK_VERSION,
     errors::{
@@ -76,6 +76,7 @@ impl ConsensusApi for ConsensusMock {
         &self,
         miner_data: MinerData,
         mut tx_selector: Box<dyn TemplateTransactionSelector>,
+        _build_mode: TemplateBuildMode,
     ) -> Result<BlockTemplate, RuleError> {
         let mut txs = tx_selector.select_transactions();
         let coinbase_manager = CoinbaseManagerMock::new();

--- a/simpa/src/simulator/miner.rs
+++ b/simpa/src/simulator/miner.rs
@@ -4,7 +4,7 @@ use kaspa_consensus::consensus::Consensus;
 use kaspa_consensus::model::stores::virtual_state::VirtualStateStoreReader;
 use kaspa_consensus::params::Params;
 use kaspa_consensus_core::api::ConsensusApi;
-use kaspa_consensus_core::block::Block;
+use kaspa_consensus_core::block::{Block, TemplateTransactionSelector};
 use kaspa_consensus_core::coinbase::MinerData;
 use kaspa_consensus_core::sign::sign;
 use kaspa_consensus_core::subnets::SUBNETWORK_ID_NATIVE;
@@ -21,6 +21,26 @@ use rayon::prelude::{IntoParallelIterator, ParallelIterator};
 use std::cmp::max;
 use std::iter::once;
 use std::sync::Arc;
+
+struct OnetimeTxSelector {
+    txs: Option<Vec<Transaction>>,
+}
+
+impl OnetimeTxSelector {
+    fn new(txs: Vec<Transaction>) -> Self {
+        Self { txs: Some(txs) }
+    }
+}
+
+impl TemplateTransactionSelector for OnetimeTxSelector {
+    fn select_transactions(&mut self) -> Vec<Transaction> {
+        self.txs.take().unwrap()
+    }
+
+    fn reject_selection(&mut self, _tx_id: kaspa_consensus_core::tx::TransactionId) {
+        unimplemented!()
+    }
+}
 
 pub struct Miner {
     // ID
@@ -89,7 +109,7 @@ impl Miner {
         let session = self.consensus.acquire_session();
         let mut block_template = self
             .consensus
-            .build_block_template(self.miner_data.clone(), txs)
+            .build_block_template(self.miner_data.clone(), Box::new(OnetimeTxSelector::new(txs)))
             .expect("simulation txs are selected in sync with virtual state and are expected to be valid");
         drop(session);
         block_template.block.header.timestamp = timestamp; // Use simulation time rather than real time

--- a/simpa/src/simulator/miner.rs
+++ b/simpa/src/simulator/miner.rs
@@ -40,6 +40,10 @@ impl TemplateTransactionSelector for OnetimeTxSelector {
     fn reject_selection(&mut self, _tx_id: kaspa_consensus_core::tx::TransactionId) {
         unimplemented!()
     }
+
+    fn is_successful(&self) -> bool {
+        true
+    }
 }
 
 pub struct Miner {

--- a/simpa/src/simulator/miner.rs
+++ b/simpa/src/simulator/miner.rs
@@ -4,7 +4,7 @@ use kaspa_consensus::consensus::Consensus;
 use kaspa_consensus::model::stores::virtual_state::VirtualStateStoreReader;
 use kaspa_consensus::params::Params;
 use kaspa_consensus_core::api::ConsensusApi;
-use kaspa_consensus_core::block::{Block, TemplateTransactionSelector};
+use kaspa_consensus_core::block::{Block, TemplateBuildMode, TemplateTransactionSelector};
 use kaspa_consensus_core::coinbase::MinerData;
 use kaspa_consensus_core::sign::sign;
 use kaspa_consensus_core::subnets::SUBNETWORK_ID_NATIVE;
@@ -113,7 +113,7 @@ impl Miner {
         let session = self.consensus.acquire_session();
         let mut block_template = self
             .consensus
-            .build_block_template(self.miner_data.clone(), Box::new(OnetimeTxSelector::new(txs)))
+            .build_block_template(self.miner_data.clone(), Box::new(OnetimeTxSelector::new(txs)), TemplateBuildMode::Standard)
             .expect("simulation txs are selected in sync with virtual state and are expected to be valid");
         drop(session);
         block_template.block.header.timestamp = timestamp; // Use simulation time rather than real time


### PR DESCRIPTION
Make tx selector iterative and perform retry logic within virtual read lock hence reducing consensus<->mempool sync gap